### PR TITLE
Update environment vars

### DIFF
--- a/.github/workflows/deployLambda.yml
+++ b/.github/workflows/deployLambda.yml
@@ -41,12 +41,10 @@ jobs:
       run: go test -v ./...
     
     - name: Setup Artifactory
-      run: 
-          jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER" --password "$ART_PASS" --interactive=false
+      uses: jfrog/setup-jfrog@v1
       env:
-        ART_USER: ${{ secrets.USERNAME }}
-        ART_PASS: ${{secrets.PASSWORD}}
-    
-    - name:
-      run:
-        jfrog rt gp deployLambda 1.0.0 --server-id rt-server
+        JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }} 
+
+    - name: 
+      run: |
+        jfrog rt gp deployLambda --server-id rt-server

--- a/.github/workflows/deployLambda.yml
+++ b/.github/workflows/deployLambda.yml
@@ -18,9 +18,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1.13
-    
-    - name: Setup JFrog CLI
-      uses: jfrog/setup-jfrog-cli@v1.1.0
 
     
     - name: Check out code into the Go module directory
@@ -47,4 +44,4 @@ jobs:
 
     - name: 
       run: |
-        jfrog rt gp deployLambda --server-id rt-server
+        jfrog rt gp deployLambda 1.0.0 --server-id rt-server

--- a/.github/workflows/deployLambda.yml
+++ b/.github/workflows/deployLambda.yml
@@ -41,7 +41,7 @@ jobs:
       run: go test -v ./...
     
     - name: Setup Artifactory
-      uses: jfrog/setup-jfrog@v1
+      uses: jfrog/setup-jfrog@v1.1.0
       env:
         JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }} 
 

--- a/.github/workflows/deployLambda.yml
+++ b/.github/workflows/deployLambda.yml
@@ -40,8 +40,8 @@ jobs:
     - name: Test
       run: go test -v ./...
     
-    - name: Setup Artifactory
-      uses: jfrog/setup-jfrog@v1.1.0
+    - name: Setup JFrog CLI
+      uses: jfrog/setup-jfrog-cli@v1.1.0
       env:
         JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }} 
 

--- a/.github/workflows/deployLambda.yml
+++ b/.github/workflows/deployLambda.yml
@@ -44,4 +44,4 @@ jobs:
 
     - name: 
       run: |
-        jfrog rt gp deployLambda 1.0.0 --server-id rt-server
+        jfrog rt gp deployLambda v1.0.0 --server-id rt-server

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
-    - name: Setup Variables
-      env:
-        ART_USER: ${{ secrets.USERNAME }}
-        ART_PASS: ${{secrets.PASSWORD}}
+      
     
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -46,4 +42,7 @@ jobs:
     
     - name: Push to artifactory
       run: |
-        jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER --password "$ART_PASS" --interactive=false
+          jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER --password "$ART_PASS" --interactive=false
+      env:
+        ART_USER: ${{ secrets.USERNAME }}
+        ART_PASS: ${{secrets.PASSWORD}}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,9 +40,13 @@ jobs:
     - name: Test
       run: go test -v ./...
     
-    - name: Push to artifactory
-      run: |
+    - name: Setup Artifactory
+      run: 
           jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER" --password "$ART_PASS" --interactive=false
       env:
         ART_USER: ${{ secrets.USERNAME }}
         ART_PASS: ${{secrets.PASSWORD}}
+    
+    - name:
+      run:
+        jfrog rt gp deployLambda 1.0.0 --server-id rt-server

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,49 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Setup Variables
+      env:
+        ART_USER: ${{ secrets.USERNAME }}
+        ART_PASS: ${{secrets.PASSWORD}}
+    
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+    
+    - name: Setup JFrog CLI
+      uses: jfrog/setup-jfrog-cli@v1.1.0
+
+    
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+    
+    - name: Push to artifactory
+      run: |
+        jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER --password "$ART_PASS" --interactive=false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
     
     - name: Push to artifactory
       run: |
-          jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER --password "$ART_PASS" --interactive=false
+          jfrog rt c rt-server -url https://ascipack.jfrog.io/artifactory --user "$ART_USER" --password "$ART_PASS" --interactive=false
       env:
         ART_USER: ${{ secrets.USERNAME }}
         ART_PASS: ${{secrets.PASSWORD}}

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ release-check:
 build_linux_amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -a -tags '$(TAGS)' -ldflags '$(EXTLDFLAGS)-s -w $(LDFLAGS)' -o release/linux/amd64/$(DEPLOY_IMAGE)
 
+build_mac_amd64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build -a -tags '$(TAGS)' -ldflags '$(EXTLDFLAGS)-s -w $(LDFLAGS)' -o release/mac/amd64/$(DEPLOY_IMAGE)
+
 build_linux_i386:
 	CGO_ENABLED=0 GOOS=linux GOARCH=386 $(GO) build -a -tags '$(TAGS)' -ldflags '$(EXTLDFLAGS)-s -w $(LDFLAGS)' -o release/linux/i386/$(DEPLOY_IMAGE)
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/appleboy/drone-lambda
+module github.com/ascendsoftware/drone-lambda
 
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.35.13
+	github.com/aws/aws-sdk-go v1.36.2
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/mholt/archiver/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 h1:bZ28Hqta7TFA
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6/go.mod h1:+lx6/Aqd1kLJ1GQfkvOnaZ1WGmLpMpbprPuIOOZX30U=
 github.com/aws/aws-sdk-go v1.35.13 h1:Y49GifH2czbooBMkVpoXwokur1JRBFKVLVCQzO0YsW8=
 github.com/aws/aws-sdk-go v1.35.13/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/aws/aws-sdk-go v1.36.2 h1:UAeFPct+jHqWM+tgiqDrC9/sfbWj6wkcvpsJ+zdcsvA=
+github.com/aws/aws-sdk-go v1.36.2/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -60,11 +62,18 @@ github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/main.go
+++ b/main.go
@@ -40,14 +40,12 @@ func main() {
 			Value:  "us-east-1",
 		},
 		cli.StringFlag{
-			Name:   "access-key",
-			Usage:  "AWS ACCESS KEY",
-			EnvVar: "PLUGIN_ACCESS_KEY,PLUGIN_AWS_ACCESS_KEY_ID,AWS_ACCESS_KEY_ID,INPUT_AWS_ACCESS_KEY_ID",
+			Name:  "access-key",
+			Usage: "AWS ACCESS KEY",
 		},
 		cli.StringFlag{
-			Name:   "secret-key",
-			Usage:  "AWS SECRET KEY",
-			EnvVar: "PLUGIN_SECRET_KEY,PLUGIN_AWS_SECRET_ACCESS_KEY,AWS_SECRET_ACCESS_KEY,INPUT_AWS_SECRET_ACCESS_KEY",
+			Name:  "secret-key",
+			Usage: "AWS SECRET KEY",
 		},
 		cli.StringFlag{
 			Name:   "session-token",
@@ -134,6 +132,10 @@ func main() {
 			Usage:  "The identifier of the function's runtime.",
 			EnvVar: "PLUGIN_RUNTIME,RUNTIME,INPUT_RUNTIME",
 		},
+		cli.StringFlag{
+			Name:  "update-conf",
+			Usage: "Update Lambda Environment variables with prefixed ENV VARS",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -163,6 +165,7 @@ func run(c *cli.Context) error {
 			Handler:         c.String("handler"),
 			Role:            c.String("role"),
 			Runtime:         c.String("runtime"),
+			EnvPrefix:       c.String("update-conf"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -38,6 +38,7 @@ type (
 		Handler         string
 		Role            string
 		Runtime         string
+		EnvPrefix       string
 	}
 
 	// Plugin values.
@@ -147,6 +148,11 @@ func (p Plugin) Exec() error {
 		isUpdateConfig = true
 		cfg.SetRuntime(p.Config.Runtime)
 	}
+	if len(p.Config.EnvPrefix) > 0 {
+		isUpdateConfig = true
+		envVars := getPrefixVars(p.Config.EnvPrefix, os.Environ())
+		cfg.Environment.SetVariables(envVars)
+	}
 
 	svc := lambda.New(sess, config)
 
@@ -246,4 +252,15 @@ func globList(paths []string) []string {
 	}
 
 	return newPaths
+}
+
+func getPrefixVars(prefix string, Environment []string) (output map[string]*string) {
+
+	for _, e := range Environment {
+		if strings.HasPrefix(e, prefix) {
+			pair := strings.SplitN(e, "=", 2)
+			output[strings.TrimPrefix(pair[0], prefix)] = &pair[2]
+		}
+	}
+	return
 }

--- a/plugin.go
+++ b/plugin.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -151,6 +150,7 @@ func (p Plugin) Exec() error {
 	}
 	if len(p.Config.EnvPrefix) > 0 {
 		isUpdateConfig = true
+		//All variables are overriden to this new map, non-present key value pairs are removed from the lambda
 		cfg.Environment = &lambda.Environment{
 			Variables: getPrefixVars(p.Config.EnvPrefix, os.Environ()),
 		}
@@ -256,11 +256,12 @@ func globList(paths []string) []string {
 	return newPaths
 }
 
+//getPrefixVars takes a list of KEY=VALUE strings and turns it into a aws String Map
 func getPrefixVars(prefix string, Environment []string) map[string]*string {
 	output := make(map[string]string)
 	for _, e := range Environment {
+		//check if the prefix is on each environment var, split and store key/values in map
 		if strings.HasPrefix(e, prefix) {
-			fmt.Println(e)
 			pair := strings.SplitN(e, "=", 2)
 			output[strings.TrimPrefix(pair[0], prefix)] = pair[1]
 		}

--- a/plugin.go
+++ b/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -150,8 +151,9 @@ func (p Plugin) Exec() error {
 	}
 	if len(p.Config.EnvPrefix) > 0 {
 		isUpdateConfig = true
-		envVars := getPrefixVars(p.Config.EnvPrefix, os.Environ())
-		cfg.Environment.SetVariables(envVars)
+		cfg.Environment = &lambda.Environment{
+			Variables: getPrefixVars(p.Config.EnvPrefix, os.Environ()),
+		}
 	}
 
 	svc := lambda.New(sess, config)
@@ -254,13 +256,14 @@ func globList(paths []string) []string {
 	return newPaths
 }
 
-func getPrefixVars(prefix string, Environment []string) (output map[string]*string) {
-
+func getPrefixVars(prefix string, Environment []string) map[string]*string {
+	output := make(map[string]string)
 	for _, e := range Environment {
 		if strings.HasPrefix(e, prefix) {
+			fmt.Println(e)
 			pair := strings.SplitN(e, "=", 2)
-			output[strings.TrimPrefix(pair[0], prefix)] = &pair[2]
+			output[strings.TrimPrefix(pair[0], prefix)] = pair[1]
 		}
 	}
-	return
+	return aws.StringMap(output)
 }

--- a/plugin.go
+++ b/plugin.go
@@ -150,7 +150,7 @@ func (p Plugin) Exec() error {
 	}
 	if len(p.Config.EnvPrefix) > 0 {
 		isUpdateConfig = true
-		//All variables are overriden to this new map, non-present key value pairs are removed from the lambda
+		//All variables are overridden to this new map, non-present key value pairs are removed from the lambda
 		cfg.Environment = &lambda.Environment{
 			Variables: getPrefixVars(p.Config.EnvPrefix, os.Environ()),
 		}


### PR DESCRIPTION
Using a prefix for environment variables i have added a function and logic to take local ENV vars and copy them to AWS.

getPrefixVars takes a list of KEY=VALUE strings and turns it into a aws String Map

Right now all the vars are overridden so if something is missing from the map it will be removed from the lambda


also added a make file line for Mac OS builds. 


added flag to set env var prefix
``` --update-conf <PREFIX> ```