### PR TITLE
feat: add session token support to CLI plugin authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,11 @@ func main() {
 			Usage:  "A description of the function.",
 			EnvVar: "PLUGIN_DESCRIPTION,DESCRIPTION,INPUT_DESCRIPTION",
 		},
+		cli.StringFlag{
+			Name:   "session-token",
+			Usage:  "session token for static credentials",
+			EnvVar: "PLUGIN_SESSION_TOKEN,SESSION_TOKEN,INPUT_SESSION_TOKEN",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -209,6 +214,7 @@ func run(c *cli.Context) error {
 			Subnets:         c.StringSlice("subnets"),
 			SecurityGroups:  c.StringSlice("securitygroups"),
 			Description:     c.String("description"),
+			SessionToken:    c.String("session-token"),
 		},
 		Commit: Commit{
 			Sha:    c.String("commit.sha"),

--- a/plugin.go
+++ b/plugin.go
@@ -44,6 +44,7 @@ type (
 		SecurityGroups  []string
 		Description     string
 		Layers          []string
+		SessionToken    string
 	}
 
 	// Commit information.
@@ -112,7 +113,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Config.AccessKey != "" && p.Config.SecretKey != "" {
-		config.Credentials = credentials.NewStaticCredentials(p.Config.AccessKey, p.Config.SecretKey, "")
+		config.Credentials = credentials.NewStaticCredentials(p.Config.AccessKey, p.Config.SecretKey, p.Config.SessionToken)
 	}
 
 	if p.Config.DryRun {


### PR DESCRIPTION
- Add a `session-token` flag to the CLI
- Pass the session token to `NewStaticCredentials` in plugin.go

fix #15 