### PR TITLE
feat: add X-Ray tracing configuration to CLI and `Plugin` struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,11 @@ func main() {
 			Usage:   "A description of the function.",
 			EnvVars: []string{"PLUGIN_DESCRIPTION", "DESCRIPTION", "INPUT_DESCRIPTION"},
 		},
+		&cli.StringFlag{
+			Name:    "tracing-mode",
+			Usage:   "The function's X-Ray tracing configuration.",
+			EnvVars: []string{"PLUGIN_TRACING_MODE", "TRACING_MODE", "INPUT_TRACING_MODE"},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -210,6 +215,7 @@ func run(c *cli.Context) error {
 			SecurityGroups:  c.StringSlice("securitygroups"),
 			Description:     c.String("description"),
 			SessionToken:    c.String("session-token"),
+			TracingMode:     c.String("tracing-mode"),
 		},
 		Commit: Commit{
 			Sha:    c.String("commit.sha"),

--- a/plugin.go
+++ b/plugin.go
@@ -45,6 +45,7 @@ type (
 		Description     string
 		Layers          []string
 		SessionToken    string
+		TracingMode     string
 	}
 
 	// Commit information.
@@ -210,6 +211,13 @@ func (p Plugin) Exec() error {
 		cfg.SetVpcConfig(&lambda.VpcConfig{
 			SubnetIds:        aws.StringSlice(subnets),
 			SecurityGroupIds: aws.StringSlice(securityGroups),
+		})
+	}
+
+	if p.Config.TracingMode != "" {
+		isUpdateConfig = true
+		cfg.SetTracingConfig(&lambda.TracingConfig{
+			Mode: aws.String(p.Config.TracingMode),
 		})
 	}
 


### PR DESCRIPTION
- Add a new CLI flag for X-Ray tracing configuration
- Update `Plugin` struct with a new `TracingMode` field
- Set the new `TracingMode` field in `Exec` method if provided in the config

refer to https://github.com/appleboy/lambda-action/issues/52