### PR TITLE
feat: improve retry logic for AWS Lambda deployments

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,6 +179,12 @@ func main() {
 			Usage:   "The function's X-Ray tracing configuration.",
 			EnvVars: []string{"PLUGIN_TRACING_MODE", "TRACING_MODE", "INPUT_TRACING_MODE"},
 		},
+		&cli.IntFlag{
+			Name:    "max-attempts",
+			Usage:   "the maximum number of times the waiter should attempt to check the resource for the target state",
+			EnvVars: []string{"PLUGIN_MAX_ATTEMPTS", "MAX_ATTEMPTS", "INPUT_MAX_ATTEMPTS"},
+			Value:   200,
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -216,6 +222,7 @@ func run(c *cli.Context) error {
 			Description:     c.String("description"),
 			SessionToken:    c.String("session-token"),
 			TracingMode:     c.String("tracing-mode"),
+			MaxAttempts:     c.Int("max-attempts"),
 		},
 		Commit: Commit{
 			Sha:    c.String("commit.sha"),


### PR DESCRIPTION
- Add a new cli flag `max-attempts` with default value 200
- Update `run` function to read `max-attempts` from the cli context
- Replace `svc.WaitUntilFunctionUpdated` with `svc.WaitUntilFunctionUpdatedWithContext`
- Use `request.WithWaiterMaxAttempts` to set max attempts in `Exec` function

refer to: https://github.com/appleboy/lambda-action/issues/58
https://github.com/hashicorp/packer/issues/6569