### PR TITLE
feat: add IPv6 dual-stack support for Lambda functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,6 +197,11 @@ func main() {
 			Usage:   "determines the type of computer processor that Lambda uses to run the function.",
 			EnvVars: []string{"PLUGIN_ARCHITECTURES", "ARCHITECTURES", "INPUT_ARCHITECTURES"},
 		},
+		&cli.BoolFlag{
+			Name:    "ipv6-dual-stack",
+			Usage:   "Enables or disables dual-stack IPv6 support in the VPC configuration for the Lambda function.",
+			EnvVars: []string{"PLUGIN_IPV6_DUAL_STACK", "IPV6_DUAL_STACK", "INPUT_IPV6_DUAL_STACK"},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -236,6 +241,7 @@ func run(c *cli.Context) error {
 			TracingMode:     c.String("tracing-mode"),
 			MaxAttempts:     c.Int("max-attempts"),
 			Architectures:   c.StringSlice("architectures"),
+			IP6DualStack:    c.Bool("ipv6-dual-stack"),
 		},
 		Commit: Commit{
 			Sha:    c.String("commit.sha"),

--- a/plugin.go
+++ b/plugin.go
@@ -50,6 +50,7 @@ type (
 		TracingMode     string
 		MaxAttempts     int
 		Architectures   []string
+		IP6DualStack    bool
 	}
 
 	// Commit information.
@@ -215,8 +216,9 @@ func (p Plugin) Exec() error { //nolint:gocyclo
 	if len(subnets) > 0 || len(securityGroups) > 0 {
 		isUpdateConfig = true
 		cfg.SetVpcConfig(&lambda.VpcConfig{
-			SubnetIds:        aws.StringSlice(subnets),
-			SecurityGroupIds: aws.StringSlice(securityGroups),
+			Ipv6AllowedForDualStack: aws.Bool(p.Config.IP6DualStack),
+			SubnetIds:               aws.StringSlice(subnets),
+			SecurityGroupIds:        aws.StringSlice(securityGroups),
 		})
 	}
 


### PR DESCRIPTION
- Add a new CLI flag `ipv6-dual-stack` to enable or disable dual-stack IPv6 support in the VPC configuration for the Lambda function
- Add environment variables for the `ipv6-dual-stack` flag
- Update the `run` function to handle the new `ipv6-dual-stack` flag
- Add a new boolean field `IP6DualStack` to the configuration struct
- Update the `Exec` function to set `Ipv6AllowedForDualStack` based on the new `IP6DualStack` field